### PR TITLE
fix: Se corrige bug null en signature

### DIFF
--- a/src/main/java/com/unsis/scunsis_backend/mapper/signature/SignatureMapper.java
+++ b/src/main/java/com/unsis/scunsis_backend/mapper/signature/SignatureMapper.java
@@ -29,7 +29,13 @@ public class SignatureMapper implements BaseMapper<SignatureResponse, SignatureR
 
     @Override
     public SignatureResponse toDto(Signature entity) {
-        return SignatureResponse.builder().build();
+        return SignatureResponse.builder()
+        .academicGrade(entity.getAcademicGrade())
+        .lastName(entity.getLastName())
+        .name(entity.getName())
+        .position(entity.getPosition())
+        .twoLastName(entity.getTwoLastName())
+        .build();
     }
 
     @Override


### PR DESCRIPTION
El mapper estaba haciendo el build vacio y por eso compilaba pero no devolvia nada al dto