### PR TITLE
refactor(dto): flatten DTOs, remove entity exposure

### DIFF
--- a/src/main/java/com/unsis/scunsis_backend/dto/request/activity/ActivityRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/activity/ActivityRequest.java
@@ -1,10 +1,6 @@
 package com.unsis.scunsis_backend.dto.request.activity;
 
-import java.sql.Date;
-
-import com.unsis.scunsis_backend.model.event.Event;
-
-
+import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,19 +12,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ActivityRequest {
-
-    private long activityId;
-
-    private Event eventId;
-
+    private Long eventId;
     private String activityName;
-
     private String activityDescription;
-
-    private Date startDate;
-
-    private Date endDate;
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String activityPlace;
-
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/event/EventRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/event/EventRequest.java
@@ -1,6 +1,6 @@
 package com.unsis.scunsis_backend.dto.request.event;
 
-import java.sql.Date;
+import java.time.LocalDate;
 
 import com.unsis.scunsis_backend.model.enums.EEventType;
 
@@ -14,16 +14,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class EventRequest {
-
     private EEventType eventType;
-
     private String eventName;
-
-    private Date startDate;
-
-    private Date endDate;
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String eventPlace;
-
     private String eventDescription;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/proof/ProofRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/proof/ProofRequest.java
@@ -1,36 +1,20 @@
 package com.unsis.scunsis_backend.dto.request.proof;
 
-import java.sql.Date;
+import com.unsis.scunsis_backend.model.enums.EParticipationRole;
 
-import com.unsis.scunsis_backend.model.activity.Activity;
-import com.unsis.scunsis_backend.model.enums.EProofType;
-import com.unsis.scunsis_backend.model.event.Event;
-import com.unsis.scunsis_backend.model.receiver.Receiver;
-import com.unsis.scunsis_backend.model.sender.Sender;
-
-import io.micrometer.common.lang.NonNull;
-import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProofRequest {
-    @NonNull
-    @NotBlank
-    private Sender sender;
-    @NonNull
-    @NotBlank
-    private Receiver receiver;    
-    @NotBlank
-    @NonNull
-    private Activity activity;
-    @NotBlank
-    @NonNull
-    private Event event;
-    
-    private EProofType proofType;
-    @NonNull
-    @NotBlank
-    private Date date;
+    private Long senderId;
+    private Long receiverId;
+    private Long activityId;
+    private Long eventId;
+    private EParticipationRole role;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/receiver/ReceiverRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/receiver/ReceiverRequest.java
@@ -1,21 +1,19 @@
 package com.unsis.scunsis_backend.dto.request.receiver;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReceiverRequest {
-
     private String name;
-
     private String lastName;
-
     private String twoLastName;
-
     private String phone;
-
     private String email;
-
     private String academicGrade;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/sender/SenderRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/sender/SenderRequest.java
@@ -1,13 +1,15 @@
 package com.unsis.scunsis_backend.dto.request.sender;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SenderRequest {
-
     private String name;
-
     private String campus;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/activity/ActivityResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/activity/ActivityResponse.java
@@ -1,30 +1,23 @@
 package com.unsis.scunsis_backend.dto.response.activity;
 
-import java.sql.Date;
-
-import com.unsis.scunsis_backend.model.event.Event;
+import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ActivityResponse {
-    
-    private long activityId;
-
-    private Event eventId;
-
+    private Long activityId;
+    private Long eventId;
+    private String eventName;
     private String activityName;
-
     private String activityDescription;
-
-    private Date startDate;
-
-    private Date endDate;
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String activityPlace;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/event/EventResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/event/EventResponse.java
@@ -1,6 +1,6 @@
 package com.unsis.scunsis_backend.dto.response.event;
 
-import java.sql.Date;
+import java.time.LocalDate;
 
 import com.unsis.scunsis_backend.model.enums.EEventType;
 
@@ -14,15 +14,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EventResponse {
+    private Long eventId;
     private EEventType eventType;
-
     private String eventName;
-
-    private Date startDate;
-
-    private Date endDate;
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String eventPlace;
-
     private String eventDescription;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/proof/ProofBulkResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/proof/ProofBulkResponse.java
@@ -1,0 +1,20 @@
+package com.unsis.scunsis_backend.dto.response.proof;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProofBulkResponse {
+    private int totalRows;
+    private int successCount;
+    private int errorCount;
+    private List<String> generatedFolios;
+    private List<String> errors;
+}

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/proof/ProofResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/proof/ProofResponse.java
@@ -1,31 +1,29 @@
 package com.unsis.scunsis_backend.dto.response.proof;
 
-import java.sql.Date;
+import java.time.LocalDate;
 
-import com.unsis.scunsis_backend.model.activity.Activity;
-import com.unsis.scunsis_backend.model.enums.EProofType;
-import com.unsis.scunsis_backend.model.event.Event;
-import com.unsis.scunsis_backend.model.receiver.Receiver;
-import com.unsis.scunsis_backend.model.sender.Sender;
+import com.unsis.scunsis_backend.model.enums.EParticipationRole;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProofResponse {
-
     private String folio;
-
-    private Sender sender;
-
-    private Receiver receiver;    
-
-    private Activity activity;
-
-    private Event event;
-
-    private EProofType proofType;
-
-    private Date date;
+    private Long senderId;
+    private String senderName;
+    private Long receiverId;
+    private String receiverFullName;
+    private String receiverEmail;
+    private Long activityId;
+    private String activityName;
+    private Long eventId;
+    private String eventName;
+    private EParticipationRole role;
+    private LocalDate date;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/receiver/ReceiverResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/receiver/ReceiverResponse.java
@@ -1,21 +1,20 @@
 package com.unsis.scunsis_backend.dto.response.receiver;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReceiverResponse {
-
+    private Long receiverId;
     private String name;
-
     private String lastName;
-
     private String twoLastName;
-
     private String phone;
-
     private String email;
-
     private String academicGrade;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/sender/SenderResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/sender/SenderResponse.java
@@ -1,13 +1,16 @@
 package com.unsis.scunsis_backend.dto.response.sender;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SenderResponse {
-
+    private Long senderId;
     private String name;
-
     private String campus;
 }


### PR DESCRIPTION
Descripcion:
  - ActivityRequest: cambia Event eventId por Long eventId (referencia
    por ID en vez de objeto completo)
  - ActivityResponse: agrega eventId, eventName (denormalizado para
    el frontend)
  - EventResponse: agrega eventId faltante
  - ProofRequest: cambia Sender/Receiver/Activity/Event por
    senderId/receiverId/activityId/eventId; elimina @NotBlank invalido
    sobre tipos objeto
  - ProofResponse: plano con senderId, senderName, receiverId,
    receiverFullName, receiverEmail, activityId, activityName, eventId,
    eventName (sin exponer entidades JPA)
  - ReceiverResponse/ReceiverRequest: agrega receiverId
  - SenderResponse/SenderRequest: agrega senderId
  - Nuevo ProofBulkResponse para respuesta de carga masiva