### PR TITLE
Refactor/mappers

### DIFF
--- a/src/main/java/com/unsis/scunsis_backend/dto/request/activity/ActivityRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/activity/ActivityRequest.java
@@ -1,10 +1,6 @@
 package com.unsis.scunsis_backend.dto.request.activity;
 
-import java.sql.Date;
-
-import com.unsis.scunsis_backend.model.event.Event;
-
-
+import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,19 +12,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ActivityRequest {
-
-    private long activityId;
-
-    private Event eventId;
-
+    private Long eventId;
     private String activityName;
-
     private String activityDescription;
-
-    private Date startDate;
-
-    private Date endDate;
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String activityPlace;
-
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/event/EventRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/event/EventRequest.java
@@ -1,6 +1,6 @@
 package com.unsis.scunsis_backend.dto.request.event;
 
-import java.sql.Date;
+import java.time.LocalDate;
 
 import com.unsis.scunsis_backend.model.enums.EEventType;
 
@@ -14,16 +14,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class EventRequest {
-
     private EEventType eventType;
-
     private String eventName;
-
-    private Date startDate;
-
-    private Date endDate;
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String eventPlace;
-
     private String eventDescription;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/proof/ProofRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/proof/ProofRequest.java
@@ -1,36 +1,20 @@
 package com.unsis.scunsis_backend.dto.request.proof;
 
-import java.sql.Date;
+import com.unsis.scunsis_backend.model.enums.EParticipationRole;
 
-import com.unsis.scunsis_backend.model.activity.Activity;
-import com.unsis.scunsis_backend.model.enums.EProofType;
-import com.unsis.scunsis_backend.model.event.Event;
-import com.unsis.scunsis_backend.model.receiver.Receiver;
-import com.unsis.scunsis_backend.model.sender.Sender;
-
-import io.micrometer.common.lang.NonNull;
-import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProofRequest {
-    @NonNull
-    @NotBlank
-    private Sender sender;
-    @NonNull
-    @NotBlank
-    private Receiver receiver;    
-    @NotBlank
-    @NonNull
-    private Activity activity;
-    @NotBlank
-    @NonNull
-    private Event event;
-    
-    private EProofType proofType;
-    @NonNull
-    @NotBlank
-    private Date date;
+    private Long senderId;
+    private Long receiverId;
+    private Long activityId;
+    private Long eventId;
+    private EParticipationRole role;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/receiver/ReceiverRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/receiver/ReceiverRequest.java
@@ -1,21 +1,19 @@
 package com.unsis.scunsis_backend.dto.request.receiver;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReceiverRequest {
-
     private String name;
-
     private String lastName;
-
     private String twoLastName;
-
     private String phone;
-
     private String email;
-
     private String academicGrade;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/sender/SenderRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/sender/SenderRequest.java
@@ -1,13 +1,15 @@
 package com.unsis.scunsis_backend.dto.request.sender;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SenderRequest {
-
     private String name;
-
     private String campus;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/activity/ActivityResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/activity/ActivityResponse.java
@@ -1,30 +1,23 @@
 package com.unsis.scunsis_backend.dto.response.activity;
 
-import java.sql.Date;
-
-import com.unsis.scunsis_backend.model.event.Event;
+import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ActivityResponse {
-    
-    private long activityId;
-
-    private Event eventId;
-
+    private Long activityId;
+    private Long eventId;
+    private String eventName;
     private String activityName;
-
     private String activityDescription;
-
-    private Date startDate;
-
-    private Date endDate;
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String activityPlace;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/event/EventResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/event/EventResponse.java
@@ -1,6 +1,6 @@
 package com.unsis.scunsis_backend.dto.response.event;
 
-import java.sql.Date;
+import java.time.LocalDate;
 
 import com.unsis.scunsis_backend.model.enums.EEventType;
 
@@ -14,15 +14,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EventResponse {
+    private Long eventId;
     private EEventType eventType;
-
     private String eventName;
-
-    private Date startDate;
-
-    private Date endDate;
-
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String eventPlace;
-
     private String eventDescription;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/proof/ProofBulkResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/proof/ProofBulkResponse.java
@@ -1,0 +1,20 @@
+package com.unsis.scunsis_backend.dto.response.proof;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProofBulkResponse {
+    private int totalRows;
+    private int successCount;
+    private int errorCount;
+    private List<String> generatedFolios;
+    private List<String> errors;
+}

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/proof/ProofResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/proof/ProofResponse.java
@@ -1,31 +1,29 @@
 package com.unsis.scunsis_backend.dto.response.proof;
 
-import java.sql.Date;
+import java.time.LocalDate;
 
-import com.unsis.scunsis_backend.model.activity.Activity;
-import com.unsis.scunsis_backend.model.enums.EProofType;
-import com.unsis.scunsis_backend.model.event.Event;
-import com.unsis.scunsis_backend.model.receiver.Receiver;
-import com.unsis.scunsis_backend.model.sender.Sender;
+import com.unsis.scunsis_backend.model.enums.EParticipationRole;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProofResponse {
-
     private String folio;
-
-    private Sender sender;
-
-    private Receiver receiver;    
-
-    private Activity activity;
-
-    private Event event;
-
-    private EProofType proofType;
-
-    private Date date;
+    private Long senderId;
+    private String senderName;
+    private Long receiverId;
+    private String receiverFullName;
+    private String receiverEmail;
+    private Long activityId;
+    private String activityName;
+    private Long eventId;
+    private String eventName;
+    private EParticipationRole role;
+    private LocalDate date;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/receiver/ReceiverResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/receiver/ReceiverResponse.java
@@ -1,21 +1,20 @@
 package com.unsis.scunsis_backend.dto.response.receiver;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReceiverResponse {
-
+    private Long receiverId;
     private String name;
-
     private String lastName;
-
     private String twoLastName;
-
     private String phone;
-
     private String email;
-
     private String academicGrade;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/sender/SenderResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/sender/SenderResponse.java
@@ -1,13 +1,16 @@
 package com.unsis.scunsis_backend.dto.response.sender;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SenderResponse {
-
+    private Long senderId;
     private String name;
-
     private String campus;
 }

--- a/src/main/java/com/unsis/scunsis_backend/mapper/activity/ActivityMapper.java
+++ b/src/main/java/com/unsis/scunsis_backend/mapper/activity/ActivityMapper.java
@@ -1,65 +1,68 @@
 package com.unsis.scunsis_backend.mapper.activity;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.unsis.scunsis_backend.dto.request.activity.ActivityRequest;
 import com.unsis.scunsis_backend.dto.response.activity.ActivityResponse;
 import com.unsis.scunsis_backend.mapper.BaseMapper;
 import com.unsis.scunsis_backend.model.activity.Activity;
-
-import lombok.Data;
+import com.unsis.scunsis_backend.model.event.Event;
 import org.springframework.stereotype.Component;
 
-@Data
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
 public class ActivityMapper implements BaseMapper<ActivityResponse, ActivityRequest, Activity> {
-    
-    @Override
-    public Activity toEntity(ActivityRequest dto) {
-        return Activity.builder()
-        .activityDescription(dto.getActivityDescription())
-        .activityName(dto.getActivityName())
-        .activityPlace(dto.getActivityPlace())
-        .endDate(dto.getEndDate())
-        .eventId(dto.getEventId())
-        .startDate(dto.getStartDate())
-        .build();
-    }
 
-    public Activity toEntity(ActivityResponse dto) {
-        return Activity.builder()
-        .activityDescription(dto.getActivityDescription())
-        .activityName(dto.getActivityName())
-        .activityPlace(dto.getActivityPlace())
-        .endDate(dto.getEndDate())
-        .eventId(dto.getEventId())
-        .startDate(dto.getStartDate())
-        .build();
-    } 
+    @Override
+    public Activity toEntity(ActivityRequest request) {
+        Activity activity = new Activity();
+        activity.setEvent(Event.builder().eventId(request.getEventId()).build());
+        activity.setActivityName(request.getActivityName());
+        activity.setActivityDescription(request.getActivityDescription());
+        activity.setStartDate(request.getStartDate());
+        activity.setEndDate(request.getEndDate());
+        activity.setActivityPlace(request.getActivityPlace());
+        return activity;
+    }
 
     @Override
     public ActivityResponse toDto(Activity entity) {
-       return ActivityResponse.builder()
-       .activityDescription(entity.getActivityDescription())
-       .activityName(entity.getActivityName())
-       .activityPlace(entity.getActivityPlace())
-       .endDate(entity.getEndDate())
-       .eventId(entity.getEventId())
-       .startDate(entity.getStartDate())
-       .build();
+        return ActivityResponse.builder()
+                .activityId(entity.getActivityId())
+                .eventId(entity.getEvent() != null ? entity.getEvent().getEventId() : null)
+                .eventName(entity.getEvent() != null ? entity.getEvent().getEventName() : null)
+                .activityName(entity.getActivityName())
+                .activityDescription(entity.getActivityDescription())
+                .startDate(entity.getStartDate())
+                .endDate(entity.getEndDate())
+                .activityPlace(entity.getActivityPlace())
+                .build();
     }
 
     @Override
     public List<ActivityResponse> toDtos(List<Activity> entities) {
-       return entities.stream()
-       .map(this::toDto)
-       .collect(Collectors.toList());
+        return entities.stream().map(this::toDto).collect(Collectors.toList());
     }
 
     @Override
     public void updateEntity(ActivityRequest request, Activity entity) {
-        throw new UnsupportedOperationException("Unimplemented method 'updateEntity'");
+        if (request.getEventId() != null) {
+            entity.setEvent(Event.builder().eventId(request.getEventId()).build());
+        }
+        if (request.getActivityName() != null) {
+            entity.setActivityName(request.getActivityName());
+        }
+        if (request.getActivityDescription() != null) {
+            entity.setActivityDescription(request.getActivityDescription());
+        }
+        if (request.getStartDate() != null) {
+            entity.setStartDate(request.getStartDate());
+        }
+        if (request.getEndDate() != null) {
+            entity.setEndDate(request.getEndDate());
+        }
+        if (request.getActivityPlace() != null) {
+            entity.setActivityPlace(request.getActivityPlace());
+        }
     }
-
 }

--- a/src/main/java/com/unsis/scunsis_backend/mapper/event/EventMapper.java
+++ b/src/main/java/com/unsis/scunsis_backend/mapper/event/EventMapper.java
@@ -1,67 +1,66 @@
 package com.unsis.scunsis_backend.mapper.event;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Component;
-
 import com.unsis.scunsis_backend.dto.request.event.EventRequest;
 import com.unsis.scunsis_backend.dto.response.event.EventResponse;
 import com.unsis.scunsis_backend.mapper.BaseMapper;
-import com.unsis.scunsis_backend.model.event.Event; 
+import com.unsis.scunsis_backend.model.event.Event;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
-public class EventMapper implements BaseMapper<EventResponse, EventRequest, Event>{
+public class EventMapper implements BaseMapper<EventResponse, EventRequest, Event> {
 
     @Override
-    public Event toEntity(EventRequest dto) {
+    public Event toEntity(EventRequest request) {
         return Event.builder()
-        .endDate(dto.getEndDate())
-        .eventDescription(dto.getEventDescription())
-        .eventName(dto.getEventName())
-        .eventPlace(dto.getEventPlace())
-        .eventType(dto.getEventType())
-        .endDate(dto.getEndDate())
-        .startDate(dto.getStartDate())
-        .build();
-    }
-
-    public Event toEntity(EventResponse dto) {
-        return Event.builder()
-        .endDate(dto.getEndDate())
-        .eventDescription(dto.getEventDescription())
-        .eventName(dto.getEventName())
-        .eventPlace(dto.getEventPlace())
-        .eventType(dto.getEventType())
-        .startDate(dto.getStartDate())
-        .endDate(dto.getEndDate())
-        .build();
+                .eventType(request.getEventType())
+                .eventName(request.getEventName())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .eventPlace(request.getEventPlace())
+                .eventDescription(request.getEventDescription())
+                .build();
     }
 
     @Override
     public EventResponse toDto(Event entity) {
         return EventResponse.builder()
-        .endDate(entity.getEndDate())
-        .eventDescription(entity.getEventDescription())
-        .eventName(entity.getEventName())
-        .eventPlace(entity.getEventPlace())
-        .eventType(entity.getEventType())
-        .startDate(entity.getStartDate())
-        .endDate(entity.getEndDate())
-        .build();
+                .eventId(entity.getEventId())
+                .eventType(entity.getEventType())
+                .eventName(entity.getEventName())
+                .startDate(entity.getStartDate())
+                .endDate(entity.getEndDate())
+                .eventPlace(entity.getEventPlace())
+                .eventDescription(entity.getEventDescription())
+                .build();
     }
 
     @Override
     public List<EventResponse> toDtos(List<Event> entities) {
-            return entities.stream()
-                .map(this::toDto)
-                .collect(Collectors.toList());
+        return entities.stream().map(this::toDto).collect(Collectors.toList());
     }
 
     @Override
     public void updateEntity(EventRequest request, Event entity) {
-        throw new UnsupportedOperationException("Unimplemented method 'updateEntity'");
+        if (request.getEventType() != null) {
+            entity.setEventType(request.getEventType());
+        }
+        if (request.getEventName() != null) {
+            entity.setEventName(request.getEventName());
+        }
+        if (request.getStartDate() != null) {
+            entity.setStartDate(request.getStartDate());
+        }
+        if (request.getEndDate() != null) {
+            entity.setEndDate(request.getEndDate());
+        }
+        if (request.getEventPlace() != null) {
+            entity.setEventPlace(request.getEventPlace());
+        }
+        if (request.getEventDescription() != null) {
+            entity.setEventDescription(request.getEventDescription());
+        }
     }
-
-
-
 }

--- a/src/main/java/com/unsis/scunsis_backend/mapper/proof/ProofMapper.java
+++ b/src/main/java/com/unsis/scunsis_backend/mapper/proof/ProofMapper.java
@@ -1,56 +1,75 @@
 package com.unsis.scunsis_backend.mapper.proof;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Component;
-
 import com.unsis.scunsis_backend.dto.request.proof.ProofRequest;
 import com.unsis.scunsis_backend.dto.response.proof.ProofResponse;
 import com.unsis.scunsis_backend.mapper.BaseMapper;
+import com.unsis.scunsis_backend.model.activity.Activity;
+import com.unsis.scunsis_backend.model.event.Event;
 import com.unsis.scunsis_backend.model.proof.Proof;
+import com.unsis.scunsis_backend.model.receiver.Receiver;
+import com.unsis.scunsis_backend.model.sender.Sender;
+import org.springframework.stereotype.Component;
 
-import io.micrometer.common.lang.NonNull;
-import lombok.Data;
+import java.util.List;
+import java.util.stream.Collectors;
 
-@Data
 @Component
-public class ProofMapper implements BaseMapper<ProofResponse, ProofRequest, Proof>{@Override
-    public Proof toEntity(@NonNull ProofRequest dto) {
+public class ProofMapper implements BaseMapper<ProofResponse, ProofRequest, Proof> {
+
+    @Override
+    public Proof toEntity(ProofRequest request) {
         return Proof.builder()
-        .activity(dto.getActivity())
-        .date(dto.getDate())
-        .event(dto.getEvent())
-        .proofType(dto.getProofType())
-        .receiver(dto.getReceiver())
-        .sender(dto.getSender())
-        .build();
+                .sender(Sender.builder().senderId(request.getSenderId()).build())
+                .receiver(Receiver.builder().receiverId(request.getReceiverId()).build())
+                .activity(Activity.builder().activityId(request.getActivityId()).build())
+                .event(Event.builder().eventId(request.getEventId()).build())
+                .role(request.getRole())
+                .build();
     }
 
     @Override
     public ProofResponse toDto(Proof entity) {
-       return ProofResponse.builder()
-       .activity(entity.getActivity())
-       .date(entity.getDate())
-       .event(entity.getEvent())
-       .folio(entity.getFolio())
-       .proofType(entity.getProofType())
-       .receiver(entity.getReceiver())
-       .sender(entity.getSender())
-       .build();
+        String fullName = entity.getReceiver().getName()
+                + " " + entity.getReceiver().getLastName()
+                + (entity.getReceiver().getTwoLastName() != null ? " " + entity.getReceiver().getTwoLastName() : "");
+
+        return ProofResponse.builder()
+                .folio(entity.getFolio())
+                .senderId(entity.getSender() != null ? entity.getSender().getSenderId() : null)
+                .senderName(entity.getSender() != null ? entity.getSender().getName() : null)
+                .receiverId(entity.getReceiver() != null ? entity.getReceiver().getReceiverId() : null)
+                .receiverFullName(fullName)
+                .receiverEmail(entity.getReceiver() != null ? entity.getReceiver().getEmail() : null)
+                .activityId(entity.getActivity() != null ? entity.getActivity().getActivityId() : null)
+                .activityName(entity.getActivity() != null ? entity.getActivity().getActivityName() : null)
+                .eventId(entity.getEvent() != null ? entity.getEvent().getEventId() : null)
+                .eventName(entity.getEvent() != null ? entity.getEvent().getEventName() : null)
+                .role(entity.getRole())
+                .date(entity.getDate())
+                .build();
     }
 
     @Override
     public List<ProofResponse> toDtos(List<Proof> entities) {
-        return entities.stream()
-        .map(this::toDto)
-        .collect(Collectors.toList());
+        return entities.stream().map(this::toDto).collect(Collectors.toList());
     }
 
     @Override
     public void updateEntity(ProofRequest request, Proof entity) {
-        throw new UnsupportedOperationException("Unimplemented method 'updateEntity'");
+        if (request.getSenderId() != null) {
+            entity.setSender(Sender.builder().senderId(request.getSenderId()).build());
+        }
+        if (request.getReceiverId() != null) {
+            entity.setReceiver(Receiver.builder().receiverId(request.getReceiverId()).build());
+        }
+        if (request.getActivityId() != null) {
+            entity.setActivity(Activity.builder().activityId(request.getActivityId()).build());
+        }
+        if (request.getEventId() != null) {
+            entity.setEvent(Event.builder().eventId(request.getEventId()).build());
+        }
+        if (request.getRole() != null) {
+            entity.setRole(request.getRole());
+        }
     }
-
-
 }

--- a/src/main/java/com/unsis/scunsis_backend/mapper/receiver/ReceiverMapper.java
+++ b/src/main/java/com/unsis/scunsis_backend/mapper/receiver/ReceiverMapper.java
@@ -1,65 +1,66 @@
 package com.unsis.scunsis_backend.mapper.receiver;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Component;
-
 import com.unsis.scunsis_backend.dto.request.receiver.ReceiverRequest;
 import com.unsis.scunsis_backend.dto.response.receiver.ReceiverResponse;
 import com.unsis.scunsis_backend.mapper.BaseMapper;
 import com.unsis.scunsis_backend.model.receiver.Receiver;
+import org.springframework.stereotype.Component;
 
-import lombok.Data;
+import java.util.List;
+import java.util.stream.Collectors;
 
-@Data
 @Component
-public class ReceiverMapper implements BaseMapper<ReceiverResponse, ReceiverRequest, Receiver>{@Override
-    
-    public Receiver toEntity(ReceiverRequest dto) {
-        return Receiver.builder()
-        .academicGrade(dto.getAcademicGrade())
-        .email(dto.getEmail())
-        .lastName(dto.getLastName())
-        .name(dto.getName())
-        .phone(dto.getPhone())
-        .twoLastName(dto.getTwoLastName())
-        .build();
-    }
+public class ReceiverMapper implements BaseMapper<ReceiverResponse, ReceiverRequest, Receiver> {
 
-    public Receiver toEntity(ReceiverResponse dto) {
+    @Override
+    public Receiver toEntity(ReceiverRequest request) {
         return Receiver.builder()
-        .academicGrade(dto.getAcademicGrade())
-        .email(dto.getEmail())
-        .lastName(dto.getLastName())
-        .name(dto.getName())
-        .phone(dto.getPhone())
-        .twoLastName(dto.getTwoLastName())
-        .build();
+                .name(request.getName())
+                .lastName(request.getLastName())
+                .twoLastName(request.getTwoLastName())
+                .phone(request.getPhone())
+                .email(request.getEmail())
+                .academicGrade(request.getAcademicGrade())
+                .build();
     }
-
 
     @Override
     public ReceiverResponse toDto(Receiver entity) {
         return ReceiverResponse.builder()
-        .academicGrade(entity.getAcademicGrade())
-        .email(entity.getEmail())
-        .lastName(entity.getLastName())
-        .name(entity.getName())
-        .phone(entity.getPhone())
-        .twoLastName(entity.getTwoLastName())
-        .build();
+                .receiverId(entity.getReceiverId())
+                .name(entity.getName())
+                .lastName(entity.getLastName())
+                .twoLastName(entity.getTwoLastName())
+                .phone(entity.getPhone())
+                .email(entity.getEmail())
+                .academicGrade(entity.getAcademicGrade())
+                .build();
     }
 
     @Override
     public List<ReceiverResponse> toDtos(List<Receiver> entities) {
-        return entities.stream()
-        .map(this::toDto).collect(Collectors.toList());
+        return entities.stream().map(this::toDto).collect(Collectors.toList());
     }
 
     @Override
     public void updateEntity(ReceiverRequest request, Receiver entity) {
-        throw new UnsupportedOperationException("Unimplemented method 'updateEntity'");
+        if (request.getName() != null) {
+            entity.setName(request.getName());
+        }
+        if (request.getLastName() != null) {
+            entity.setLastName(request.getLastName());
+        }
+        if (request.getTwoLastName() != null) {
+            entity.setTwoLastName(request.getTwoLastName());
+        }
+        if (request.getPhone() != null) {
+            entity.setPhone(request.getPhone());
+        }
+        if (request.getEmail() != null) {
+            entity.setEmail(request.getEmail());
+        }
+        if (request.getAcademicGrade() != null) {
+            entity.setAcademicGrade(request.getAcademicGrade());
+        }
     }
-    
 }

--- a/src/main/java/com/unsis/scunsis_backend/mapper/sender/SenderMapper.java
+++ b/src/main/java/com/unsis/scunsis_backend/mapper/sender/SenderMapper.java
@@ -1,54 +1,46 @@
 package com.unsis.scunsis_backend.mapper.sender;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Component;
-
 import com.unsis.scunsis_backend.dto.request.sender.SenderRequest;
 import com.unsis.scunsis_backend.dto.response.sender.SenderResponse;
 import com.unsis.scunsis_backend.mapper.BaseMapper;
 import com.unsis.scunsis_backend.model.sender.Sender;
+import org.springframework.stereotype.Component;
 
-import lombok.Data;
+import java.util.List;
+import java.util.stream.Collectors;
 
-@Data
 @Component
-public class SenderMapper implements BaseMapper<SenderResponse, SenderRequest, Sender>{@Override
-    
-    public Sender toEntity(SenderRequest dto) {
-        return Sender.builder()
-        .campus(dto.getCampus())
-        .name(dto.getName())
-        .build();
-    }
+public class SenderMapper implements BaseMapper<SenderResponse, SenderRequest, Sender> {
 
-    public Sender toEntity(SenderResponse dto) {
+    @Override
+    public Sender toEntity(SenderRequest request) {
         return Sender.builder()
-        .campus(dto.getCampus())
-        .name(dto.getName())
-        .build();
+                .name(request.getName())
+                .campus(request.getCampus())
+                .build();
     }
-
 
     @Override
     public SenderResponse toDto(Sender entity) {
         return SenderResponse.builder()
-        .campus(entity.getCampus())
-        .name(entity.getName())
-        .build();
+                .senderId(entity.getSenderId())
+                .name(entity.getName())
+                .campus(entity.getCampus())
+                .build();
     }
 
     @Override
     public List<SenderResponse> toDtos(List<Sender> entities) {
-       return entities.stream().map(this::toDto)
-       .collect(Collectors.toList());
+        return entities.stream().map(this::toDto).collect(Collectors.toList());
     }
 
     @Override
     public void updateEntity(SenderRequest request, Sender entity) {
-        throw new UnsupportedOperationException("Unimplemented method 'updateEntity'");
+        if (request.getName() != null) {
+            entity.setName(request.getName());
+        }
+        if (request.getCampus() != null) {
+            entity.setCampus(request.getCampus());
+        }
     }
-
-
 }


### PR DESCRIPTION
Descripcion:
  - ActivityMapper: mapea eventId en request a Event(entity) via
    builder; response incluye eventId + eventName
  - EventMapper: corrige bug de endDate duplicado; agrega eventId en
    response; implementa updateEntity correctamente
  - ProofMapper: toEntity crea referencias por ID usando builders;
    toDto genera receiverFullName concatenado; no expone entidades
  - ReceiverMapper: agrega receiverId en response
  - SenderMapper: agrega senderId en response
  - Todos los mappers: updateEntity ahora actualiza campos no nulos
    (antes lanzaba UnsupportedOperationException)