### PR TITLE
Adapt/frontend vue integration dev 

### DIFF
--- a/src/main/java/com/unsis/scunsis_backend/controller/activity/ActivityController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/activity/ActivityController.java
@@ -33,6 +33,11 @@ public class ActivityController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @PutMapping("/{activityId}")
+    public ResponseEntity<ActivityResponse> updateActivity(@PathVariable long activityId, @RequestBody ActivityRequest request) {
+        return ResponseEntity.ok(activityService.updateActivity(activityId, request));
+    }
+
     @DeleteMapping("/{activityId}")
     public ResponseEntity<Void> deleteById(@PathVariable long activityId) {
         activityService.deleteById(activityId);

--- a/src/main/java/com/unsis/scunsis_backend/controller/activity/ActivityController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/activity/ActivityController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/scunsis/api/v1/activity")
+@RequestMapping("/api/v1/activity")
 @RequiredArgsConstructor
 public class ActivityController {
 

--- a/src/main/java/com/unsis/scunsis_backend/controller/auth/AuthController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/auth/AuthController.java
@@ -1,0 +1,23 @@
+package com.unsis.scunsis_backend.controller.auth;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+public class AuthController {
+
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, Object>> login(@RequestBody Map<String, String> credentials) {
+        String username = credentials.getOrDefault("username", "");
+        String password = credentials.getOrDefault("password", "");
+
+        if ("admin".equals(username) && "admin".equals(password)) {
+            return ResponseEntity.ok(Map.of("success", true, "message", "Inicio de sesion exitoso"));
+        }
+
+        return ResponseEntity.status(401).body(Map.of("success", false, "message", "Credenciales invalidas"));
+    }
+}

--- a/src/main/java/com/unsis/scunsis_backend/controller/event/EventController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/event/EventController.java
@@ -23,6 +23,11 @@ public class EventController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @PutMapping("/{eventId}")
+    public ResponseEntity<EventResponse> updateEvent(@PathVariable Long eventId, @RequestBody EventRequest request) {
+        return ResponseEntity.ok(eventService.updateEvent(eventId, request));
+    }
+
     @DeleteMapping("/{eventId}")
     public ResponseEntity<Void> deleteEventById(@PathVariable Long eventId) {
         eventService.deleteEventById(eventId);

--- a/src/main/java/com/unsis/scunsis_backend/controller/event/EventController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/event/EventController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/scunsis/api/v1/event")
+@RequestMapping("/api/v1/event")
 @RequiredArgsConstructor
 public class EventController {
 

--- a/src/main/java/com/unsis/scunsis_backend/controller/file/FileController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/file/FileController.java
@@ -6,8 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @RestController
 @RequestMapping("/api")
@@ -24,5 +23,41 @@ public class FileController {
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(Map.of("error", "Error al procesar el archivo: " + e.getMessage()));
         }
+    }
+
+    @PostMapping("/upload-excel")
+    public ResponseEntity<Map<String, Object>> uploadExcel(@RequestParam("file") MultipartFile file) {
+        try {
+            List<List<String>> data = excelParseService.parseToArrays(file);
+            List<Map<String, String>> folios = new ArrayList<>();
+
+            boolean hasHeader = !data.isEmpty();
+            List<String> headers = hasHeader ? data.getFirst() : List.of();
+            boolean skipFirst = hasHeader && isHeaderRow(headers);
+
+            for (int i = skipFirst ? 1 : 0; i < data.size(); i++) {
+                List<String> row = data.get(i);
+                Map<String, String> folioEntry = new LinkedHashMap<>();
+                folioEntry.put("nombre", row.size() > 0 ? row.get(0) : "");
+                folioEntry.put("primer_apellido", row.size() > 1 ? row.get(1) : "");
+                folioEntry.put("segundo_apellido", row.size() > 2 ? row.get(2) : "");
+                folioEntry.put("grado_academico", row.size() > 3 ? row.get(3) : "");
+                folioEntry.put("grado", row.size() > 4 ? row.get(4) : "");
+                folios.add(folioEntry);
+            }
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("folios", folios);
+            response.put("data", data);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Error al procesar el archivo: " + e.getMessage()));
+        }
+    }
+
+    private boolean isHeaderRow(List<String> row) {
+        if (row.isEmpty()) return false;
+        String first = row.get(0).toLowerCase();
+        return first.equals("nombre") || first.equals("nombres") || first.equals("name");
     }
 }

--- a/src/main/java/com/unsis/scunsis_backend/controller/file/FileController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/file/FileController.java
@@ -1,0 +1,28 @@
+package com.unsis.scunsis_backend.controller.file;
+
+import com.unsis.scunsis_backend.service.excel.ExcelParseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final ExcelParseService excelParseService;
+
+    @PostMapping("/file")
+    public ResponseEntity<Map<String, Object>> parseExcel(@RequestParam("file") MultipartFile file) {
+        try {
+            List<List<String>> data = excelParseService.parseToArrays(file);
+            return ResponseEntity.ok(Map.of("data", data));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Error al procesar el archivo: " + e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/unsis/scunsis_backend/controller/folio/FolioController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/folio/FolioController.java
@@ -1,0 +1,32 @@
+package com.unsis.scunsis_backend.controller.folio;
+
+import com.unsis.scunsis_backend.model.enums.EParticipationRole;
+import com.unsis.scunsis_backend.repository.proof.IProofRepository;
+import com.unsis.scunsis_backend.util.FolioGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Year;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class FolioController {
+
+    private final FolioGenerator folioGenerator;
+    private final IProofRepository proofRepository;
+
+    @GetMapping("/folio")
+    public ResponseEntity<Map<String, Object>> getFolio() {
+        int year = Year.now().getValue();
+        long count = proofRepository.countByRoleAndYear(EParticipationRole.PARTICIPANTE, year);
+        String nextFolio = folioGenerator.generateFolio(EParticipationRole.PARTICIPANTE, count + 1, year);
+        return ResponseEntity.ok(Map.of(
+                "folio", nextFolio,
+                "year", year,
+                "next", count + 1
+        ));
+    }
+}

--- a/src/main/java/com/unsis/scunsis_backend/controller/proof/ProofController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/proof/ProofController.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RestController
-@RequestMapping("/scunsis/api/v1/proof")
+@RequestMapping("/api/v1/proof")
 @RequiredArgsConstructor
 public class ProofController {
 

--- a/src/main/java/com/unsis/scunsis_backend/controller/receiver/ReceiverController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/receiver/ReceiverController.java
@@ -32,6 +32,11 @@ public class ReceiverController {
         return ResponseEntity.status(HttpStatus.CREATED).body(receiverService.createReceiver(request));
     }
 
+    @PutMapping("/{receiverId}")
+    public ResponseEntity<ReceiverResponse> updateReceiver(@PathVariable long receiverId, @RequestBody ReceiverRequest request) {
+        return ResponseEntity.ok(receiverService.updateReceiver(receiverId, request));
+    }
+
     @DeleteMapping("/{receiverId}")
     public ResponseEntity<Void> deleteById(@PathVariable long receiverId) {
         receiverService.deleteById(receiverId);

--- a/src/main/java/com/unsis/scunsis_backend/controller/receiver/ReceiverController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/receiver/ReceiverController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/scunsis/api/v1/receiver")
+@RequestMapping("/api/v1/receiver")
 @RequiredArgsConstructor
 public class ReceiverController {
 

--- a/src/main/java/com/unsis/scunsis_backend/controller/sender/SenderController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/sender/SenderController.java
@@ -33,6 +33,11 @@ public class SenderController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @PutMapping("/{senderId}")
+    public ResponseEntity<SenderResponse> updateSender(@PathVariable long senderId, @RequestBody SenderRequest request) {
+        return ResponseEntity.ok(senderService.updateSender(senderId, request));
+    }
+
     @DeleteMapping("/{senderId}")
     public ResponseEntity<Void> deleteById(@PathVariable long senderId) {
         senderService.deleteById(senderId);

--- a/src/main/java/com/unsis/scunsis_backend/controller/sender/SenderController.java
+++ b/src/main/java/com/unsis/scunsis_backend/controller/sender/SenderController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/scunsis/api/v1/sender")
+@RequestMapping("/api/v1/sender")
 @RequiredArgsConstructor
 public class SenderController {
 

--- a/src/main/java/com/unsis/scunsis_backend/dto/request/receiver/ReceiverRequest.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/request/receiver/ReceiverRequest.java
@@ -1,5 +1,6 @@
 package com.unsis.scunsis_backend.dto.request.receiver;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,10 +11,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReceiverRequest {
+    @JsonAlias("nombre")
     private String name;
+    @JsonAlias("primer_apellido")
     private String lastName;
+    @JsonAlias("segundo_apellido")
     private String twoLastName;
+    @JsonAlias({"telefono", "phone"})
     private String phone;
     private String email;
+    @JsonAlias("grado_academico")
     private String academicGrade;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/receiver/ReceiverResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/receiver/ReceiverResponse.java
@@ -1,5 +1,6 @@
 package com.unsis.scunsis_backend.dto.response.receiver;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,4 +18,5 @@ public class ReceiverResponse {
     private String phone;
     private String email;
     private String academicGrade;
+    private String folio;
 }

--- a/src/main/java/com/unsis/scunsis_backend/dto/response/receiver/ReceiverResponse.java
+++ b/src/main/java/com/unsis/scunsis_backend/dto/response/receiver/ReceiverResponse.java
@@ -1,6 +1,5 @@
 package com.unsis.scunsis_backend.dto.response.receiver;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/unsis/scunsis_backend/service/activity/ActivityService.java
+++ b/src/main/java/com/unsis/scunsis_backend/service/activity/ActivityService.java
@@ -53,4 +53,22 @@ public class ActivityService {
         }
         activityRepository.deleteById(activityId);
     }
+
+    @Transactional
+    public ActivityResponse updateActivity(long activityId, ActivityRequest request) {
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new AppException("Actividad no encontrada con id: " + activityId, HttpStatus.NOT_FOUND));
+        if (request.getActivityName() != null) activity.setActivityName(request.getActivityName());
+        if (request.getActivityDescription() != null) activity.setActivityDescription(request.getActivityDescription());
+        if (request.getActivityPlace() != null) activity.setActivityPlace(request.getActivityPlace());
+        if (request.getStartDate() != null) activity.setStartDate(request.getStartDate());
+        if (request.getEndDate() != null) activity.setEndDate(request.getEndDate());
+        if (request.getEventId() != null) {
+            Event event = eventRepository.findById(request.getEventId())
+                    .orElseThrow(() -> new AppException("Evento no encontrado con id: " + request.getEventId(), HttpStatus.NOT_FOUND));
+            activity.setEvent(event);
+        }
+        activity = activityRepository.save(activity);
+        return activityMapper.toDto(activity);
+    }
 }

--- a/src/main/java/com/unsis/scunsis_backend/service/event/EventService.java
+++ b/src/main/java/com/unsis/scunsis_backend/service/event/EventService.java
@@ -4,6 +4,7 @@ import com.unsis.scunsis_backend.dto.request.event.EventRequest;
 import com.unsis.scunsis_backend.dto.response.event.EventResponse;
 import com.unsis.scunsis_backend.exception.AppException;
 import com.unsis.scunsis_backend.mapper.event.EventMapper;
+import com.unsis.scunsis_backend.model.event.Event;
 import com.unsis.scunsis_backend.repository.event.IEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -39,5 +40,19 @@ public class EventService {
             throw new AppException("Evento no encontrado con id: " + eventId, HttpStatus.NOT_FOUND);
         }
         eventRepository.deleteById(eventId);
+    }
+
+    @Transactional
+    public EventResponse updateEvent(Long eventId, EventRequest request) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new AppException("Evento no encontrado con id: " + eventId, HttpStatus.NOT_FOUND));
+        if (request.getEventName() != null) event.setEventName(request.getEventName());
+        if (request.getEventDescription() != null) event.setEventDescription(request.getEventDescription());
+        if (request.getEventPlace() != null) event.setEventPlace(request.getEventPlace());
+        if (request.getEventType() != null) event.setEventType(request.getEventType());
+        if (request.getStartDate() != null) event.setStartDate(request.getStartDate());
+        if (request.getEndDate() != null) event.setEndDate(request.getEndDate());
+        event = eventRepository.save(event);
+        return eventMapper.toDto(event);
     }
 }

--- a/src/main/java/com/unsis/scunsis_backend/service/excel/ExcelParseService.java
+++ b/src/main/java/com/unsis/scunsis_backend/service/excel/ExcelParseService.java
@@ -1,0 +1,62 @@
+package com.unsis.scunsis_backend.service.excel;
+
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ExcelParseService {
+
+    public List<List<String>> parseToArrays(MultipartFile file) throws IOException {
+        List<List<String>> data = new ArrayList<>();
+
+        try (InputStream is = file.getInputStream();
+             Workbook workbook = new XSSFWorkbook(is)) {
+
+            Sheet sheet = workbook.getSheetAt(0);
+            for (Row row : sheet) {
+                List<String> rowData = new ArrayList<>();
+                for (int i = 0; i < row.getLastCellNum(); i++) {
+                    Cell cell = row.getCell(i);
+                    rowData.add(getCellValue(cell));
+                }
+                data.add(rowData);
+            }
+        }
+
+        return data;
+    }
+
+    private String getCellValue(Cell cell) {
+        if (cell == null) return "";
+        return switch (cell.getCellType()) {
+            case STRING -> cell.getStringCellValue();
+            case NUMERIC -> {
+                double val = cell.getNumericCellValue();
+                if (val == Math.floor(val) && !Double.isInfinite(val)) {
+                    yield String.valueOf((long) val);
+                }
+                yield String.valueOf(val);
+            }
+            case BOOLEAN -> String.valueOf(cell.getBooleanCellValue());
+            case FORMULA -> {
+                try {
+                    yield String.valueOf(cell.getNumericCellValue());
+                } catch (Exception e) {
+                    try {
+                        yield cell.getStringCellValue();
+                    } catch (Exception e2) {
+                        yield "";
+                    }
+                }
+            }
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/com/unsis/scunsis_backend/service/receiver/ReceiverService.java
+++ b/src/main/java/com/unsis/scunsis_backend/service/receiver/ReceiverService.java
@@ -4,13 +4,17 @@ import com.unsis.scunsis_backend.dto.request.receiver.ReceiverRequest;
 import com.unsis.scunsis_backend.dto.response.receiver.ReceiverResponse;
 import com.unsis.scunsis_backend.exception.AppException;
 import com.unsis.scunsis_backend.mapper.receiver.ReceiverMapper;
+import com.unsis.scunsis_backend.model.enums.EParticipationRole;
 import com.unsis.scunsis_backend.model.receiver.Receiver;
+import com.unsis.scunsis_backend.repository.proof.IProofRepository;
 import com.unsis.scunsis_backend.repository.receiver.IReceiverRepository;
+import com.unsis.scunsis_backend.util.FolioGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Year;
 import java.util.List;
 
 @Service
@@ -19,6 +23,8 @@ public class ReceiverService {
 
     private final IReceiverRepository receiverRepository;
     private final ReceiverMapper receiverMapper;
+    private final FolioGenerator folioGenerator;
+    private final IProofRepository proofRepository;
 
     public ReceiverResponse getById(long receiverId) {
         return receiverMapper.toDto(receiverRepository.findById(receiverId)
@@ -53,6 +59,14 @@ public class ReceiverService {
         }
         Receiver receiver = receiverMapper.toEntity(request);
         receiver = receiverRepository.save(receiver);
-        return receiverMapper.toDto(receiver);
+        ReceiverResponse response = receiverMapper.toDto(receiver);
+        response.setFolio(generateFolio());
+        return response;
+    }
+
+    private String generateFolio() {
+        int year = Year.now().getValue();
+        long count = proofRepository.countByRoleAndYear(EParticipationRole.PARTICIPANTE, year);
+        return folioGenerator.generateFolio(EParticipationRole.PARTICIPANTE, count + 1, year);
     }
 }

--- a/src/main/java/com/unsis/scunsis_backend/service/receiver/ReceiverService.java
+++ b/src/main/java/com/unsis/scunsis_backend/service/receiver/ReceiverService.java
@@ -64,6 +64,17 @@ public class ReceiverService {
         return response;
     }
 
+    @Transactional
+    public ReceiverResponse updateReceiver(long receiverId, ReceiverRequest request) {
+        Receiver receiver = receiverRepository.findById(receiverId)
+                .orElseThrow(() -> new AppException("Receptor no encontrado con id: " + receiverId, HttpStatus.NOT_FOUND));
+        receiverMapper.updateEntity(request, receiver);
+        receiver = receiverRepository.save(receiver);
+        ReceiverResponse response = receiverMapper.toDto(receiver);
+        response.setFolio(generateFolio());
+        return response;
+    }
+
     private String generateFolio() {
         int year = Year.now().getValue();
         long count = proofRepository.countByRoleAndYear(EParticipationRole.PARTICIPANTE, year);

--- a/src/main/java/com/unsis/scunsis_backend/service/sender/SenderService.java
+++ b/src/main/java/com/unsis/scunsis_backend/service/sender/SenderService.java
@@ -51,4 +51,18 @@ public class SenderService {
         }
         senderRepository.save(senderMapper.toEntity(request));
     }
+
+    @Transactional
+    public SenderResponse updateSender(long senderId, SenderRequest request) {
+        Sender sender = senderRepository.findById(senderId)
+                .orElseThrow(() -> new AppException("Emisor no encontrado con id: " + senderId, HttpStatus.NOT_FOUND));
+        if (request.getName() != null && !request.getName().isBlank()) {
+            sender.setName(request.getName().trim());
+        }
+        if (request.getCampus() != null) {
+            sender.setCampus(request.getCampus().trim());
+        }
+        sender = senderRepository.save(sender);
+        return senderMapper.toDto(sender);
+    }
 }


### PR DESCRIPTION
### Backend – Rama: adapt/frontend-vue-integration

**1. 623daa2 – refactor: change base path from /scunsis/api/v1 to /api/v1**
- Cambio `@RequestMapping` en los 5 controladores (Activity, Event, Proof, Receiver, Sender) de `/scunsis/api/v1` a `/api/v1` para que coincida con las rutas que el frontend Vue llama

**2. 0224eb2 – feat: add login endpoint at POST /api/login**
- Creo `AuthController.java` con POST `/api/login`
- Credenciales hardcoded: admin/admin
- Responde con `{ success: true/false, message: string }`

**3. b849b77 – feat: add Excel parse endpoint at POST /api/file**
- Creo `FileController.java` con POST `/api/file`
- Creo `ExcelParseService.java` para parsear .xlsx a `List<List<String>>`
- Responde con `{ data: [[headers], [filial], ...] }` para el editor de plantillas

**4. 747c6a5 – feat: add upload-excel endpoint at POST /api/upload-excel**
- Agrego POST `/api/upload-excel` al FileController
- Parsea Excel y devuelve `{ folios: [...], data: [...] }` en ambos formatos que el frontend espera
- Detecta automaticamente fila de encabezados

**5. 6f9ea6f – feat: add folio to receiver response and map Spanish JSON**
- Agrego `@JsonAlias` en ReceiverRequest para aceptar campos en español (nombre, primer_apellido, telefono, grado academico)
- Agrego campo `folio` a ReceiverResponse
- ReceiverService.createReceiver ahora genera y devuelve un folio

**6. f8d1786 – feat: add folio endpoint at GET /api/v1/folio**
- Creo `FolioController.java` con GET `/api/v1/folio`
- Devuelve el siguiente folio disponible basado en el conteo de constancias del año actual
- Responde con `{ folio, year, next }`

**7. 2c6ef2a – chore: remove unused import in ReceiverResponse**
- Elimino import `com.fasterxml.jackson.annotation.JsonProperty` no usado

**8. 3777f6b – feat: add PUT endpoints for updating entities**
- Agrego `updateSender`, `updateEvent`, `updateActivity`, `updateReceiver` en los servicios
- Agrego `@PutMapping` en los 4 controladores para edicion de registros

---

### Endpoints expuestos por el backend (mapeo frontend-backend)

| Metodo | Endpoint | Frontend |
|--------|----------|----------|
| POST | /api/login | LoginView.vue |
| POST | /api/file | EditPaperMaster.vue (parser Excel) |
| POST | /api/upload-excel | MyForm.vue (datos personas) |
| GET | /api/v1/folio | NavigationGC.vue |
| GET/POST/PUT/DELETE | /api/v1/receiver | EditPaperMaster.vue, ConfiguracionView |
| GET/POST/PUT/DELETE | /api/v1/sender | ConfiguracionView |
| GET/POST/PUT/DELETE | /api/v1/event | ConfiguracionView |
| GET/DELETE/GET.../pdf | /api/v1/proof | HistorialView.vue |
| POST | /api/v1/proof/upload | ConfiguracionView (carga masiva) |